### PR TITLE
nvidia-tegra-runtime: fix paths in graphics-core22-provider (#3)

### DIFF
--- a/nvidia-tegra-runtime/scripts/bin/graphics-core22-provider-wrapper
+++ b/nvidia-tegra-runtime/scripts/bin/graphics-core22-provider-wrapper
@@ -1,18 +1,20 @@
 #!/bin/bash
 set -euo pipefail
 
-SELF="$( cd -- "$(dirname "$0")/.." ; pwd -P )"
+SELF="$( cd -- "$(dirname "$0")/.." ; pwd -P )/usr"
+ROOT_SELF="$( cd -- "$(dirname "$0")/.." ; pwd -P )"
 
 ARCH_TRIPLET="aarch64-linux-gnu"
 # VDPAU_DRIVER_PATH only supports a single path, rely on LD_LIBRARY_PATH instead
-LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}${SELF}/lib/${ARCH_TRIPLET}:${SELF}/lib/${ARCH_TRIPLET}/vdpau:${SELF}/lib/${ARCH_TRIPLET}:${SELF}/usr/lib/${ARCH_TRIPLET}:${SELF}/usr/lib/${ARCH_TRIPLET}/nvidia
+LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}${SELF}/lib/${ARCH_TRIPLET}:${SELF}/lib/${ARCH_TRIPLET}/vdpau:${SELF}/lib/${ARCH_TRIPLET}/nvidia:${SELF}/lib/${ARCH_TRIPLET}/tegra-egl:${ROOT_SELF}/lib/${ARCH_TRIPLET}
+
 LIBGL_DRIVERS_PATH=${LIBGL_DRIVERS_PATH:+$LIBGL_DRIVERS_PATH:}${SELF}/lib/${ARCH_TRIPLET}/dri/
 LIBVA_DRIVERS_PATH=${LIBVA_DRIVERS_PATH:+$LIBVA_DRIVERS_PATH:}${SELF}/lib/${ARCH_TRIPLET}/dri/
 __EGL_VENDOR_LIBRARY_DIRS=${__EGL_VENDOR_LIBRARY_DIRS:+$__EGL_VENDOR_LIBRARY_DIRS:}${SELF}/share/glvnd/egl_vendor.d
 __EGL_EXTERNAL_PLATFORM_CONFIG_DIRS=${__EGL_EXTERNAL_PLATFORM_CONFIG_DIRS:+$__EGL_EXTERNAL_PLATFORM_CONFIG_DIRS:}${SELF}/share/egl/egl_external_platform.d
 VK_LAYER_PATH=${VK_LAYER_PATH:+$VK_LAYER_PATH:}${SELF}/share/vulkan/implicit_layer.d/:${SELF}/share/vulkan/explicit_layer.d/
 XDG_DATA_DIRS=${XDG_DATA_DIRS:+$XDG_DATA_DIRS:}${SELF}/share
-OCL_ICD_VENDORS=${OCL_ICD_VENDORS:+$OCL_ICD_VENDORS:}${SELF}/etc/OpenCL/vendors
+OCL_ICD_VENDORS=${OCL_ICD_VENDORS:+$OCL_ICD_VENDORS:}${ROOT_SELF}/etc/OpenCL/vendors
 
 export LD_LIBRARY_PATH
 export LIBGL_DRIVERS_PATH


### PR DESCRIPTION
Fix the exported paths for glvnd information, required for EGL to work properly.