### PR TITLE
Tensor RT samples: consume nvidia-tegra-drivers-36 to avoid build time errors

### DIFF
--- a/tensorrt-samples/snap/snapcraft.yaml
+++ b/tensorrt-samples/snap/snapcraft.yaml
@@ -23,6 +23,8 @@ package-repositories:
     key-server: https://repo.download.nvidia.com/jetson/jetson-ota-public.asc
     url: https://repo.download.nvidia.com/jetson/common
     architectures: [arm64]
+  - type: apt
+    ppa: ubuntu-tegra/updates
 
 plugs:
   hardware-observe:
@@ -49,7 +51,7 @@ parts:
     build-packages:
       - initramfs-tools
       - cuda-12-6
-      - nvidia-l4t-dla-compiler
+      - nvidia-tegra-drivers-36
         #- libnvinfer-bin
       - libnvinfer-samples
     stage-packages:


### PR DESCRIPTION
When being built through Git-hub actions, the nvidia-l4t-core is downloaded as an additional package from nvidia-l4t-dla-compiler and tries to access /proc/device-tree/compatible which does not exist on the GitHub runner.