### PR TITLE
Nvpmodel: bind the /usr/sbin/nvpmodel file for the jetson_clocks script to print the corresponding Power Mode

### DIFF
--- a/nvpmodel/snap/snapcraft.yaml
+++ b/nvpmodel/snap/snapcraft.yaml
@@ -67,6 +67,8 @@ layout:
     bind: $SNAP/etc/nvpmodel
   /var/lib/nvpmodel:
     bind: $SNAP_DATA/var/lib/nvpmodel
+  /usr/sbin/nvpmodel:
+    bind-file: $SNAP/usr/sbin/nvpmodel
 
 apps:
   nvpower-service:

--- a/nvpmodel/snap/snapcraft.yaml
+++ b/nvpmodel/snap/snapcraft.yaml
@@ -68,7 +68,7 @@ layout:
   /var/lib/nvpmodel:
     bind: $SNAP_DATA/var/lib/nvpmodel
   /usr/sbin/nvpmodel:
-    bind-file: $SNAP/usr/sbin/nvpmodel
+    symlink: $SNAP/usr/sbin/nvpmodel
 
 apps:
   nvpower-service:


### PR DESCRIPTION
When running `jetson-clocks-show` the power mode should be printed after all the system-clock frequencies, but it was not being displayed since the `jetson_clocks` script did not find `/usr/sbin/nvpmodel`, so there is needed a layout to bind-mount this file so it can be accessible by the script.

