### PR TITLE
Build tegra snaps from nvidial4t deb files

### DIFF
--- a/cuda-samples/README.md
+++ b/cuda-samples/README.md
@@ -46,7 +46,7 @@ $ snapcraft
 $ sudo snap install --dangerous ./cuda-samples_12.6_arm64.snap
 $
 $ sudo snap connect cuda-samples:graphics-core22 nvidia-tegra-runtime:graphics-core22
-$ sudo snap connect cuda-samples:tensorrt-libs-cuda-12 cuda-runtime:tensorrt-libs-cuda-12
+$ sudo snap connect cuda-samples:tensorrt-libs-cuda-12 tensorrt-libs:tensorrt-libs-cuda-12
 $ sudo snap connect cuda-samples:system-files
 $ sudo snap connect cuda-samples:hardware-observe
 ```

--- a/cuda-samples/snap/snapcraft.yaml
+++ b/cuda-samples/snap/snapcraft.yaml
@@ -70,12 +70,12 @@ parts:
       touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
       L4T_DEB_PACKAGES_PATH=${L4T_DEB_PACKAGES_PATH:="NVIDIA_ARCHIVE"}
       if [ "$L4T_DEB_PACKAGES_PATH" = "NVIDIA_ARCHIVE" ]; then
-        sudo apt-get update
-        sudo apt install --yes nvidia-l4t-core nvidia-l4t-cuda
+        apt update
+        apt install --yes nvidia-l4t-core nvidia-l4t-cuda
       elif [ -d $L4T_DEB_PACKAGES_PATH ]; then
-        sudo apt install -y libegl1 -f
-        sudo dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-core_*.deb
-        sudo dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-cuda_*.deb
+        apt install --yes libegl1 -f
+        dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-core_*.deb
+        dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-cuda_*.deb
       fi
       echo '/usr/local/cuda-12.6/compat' | tee -a /etc/ld.so.conf.d/000_cuda.conf
       ldconfig

--- a/cuda-samples/snap/snapcraft.yaml
+++ b/cuda-samples/snap/snapcraft.yaml
@@ -68,7 +68,15 @@ parts:
       set -x
       mkdir -p /opt/nvidia/l4t-packages/
       touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
-      apt install --yes nvidia-l4t-cuda
+      L4T_DEB_PACKAGES_PATH=${L4T_DEB_PACKAGES_PATH:="NVIDIA_ARCHIVE"}
+      if [ "$L4T_DEB_PACKAGES_PATH" = "NVIDIA_ARCHIVE" ]; then
+        sudo apt-get update
+        sudo apt install --yes nvidia-l4t-core nvidia-l4t-cuda
+      elif [ -d $L4T_DEB_PACKAGES_PATH ]; then
+        sudo apt install -y libegl1 -f
+        sudo dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-core_*.deb
+        sudo dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-cuda_*.deb
+      fi
       echo '/usr/local/cuda-12.6/compat' | tee -a /etc/ld.so.conf.d/000_cuda.conf
       ldconfig
       mkdir -p $CRAFT_PART_INSTALL/usr/bin

--- a/cudnn-samples/snap/snapcraft.yaml
+++ b/cudnn-samples/snap/snapcraft.yaml
@@ -53,8 +53,27 @@ parts:
       - autograd
   cudnn-samples:
     plugin: nil
+    override-stage: |
+      L4T_DEB_PACKAGES_PATH=${L4T_DEB_PACKAGES_PATH:="NVIDIA_ARCHIVE"}
+      if [ "$L4T_DEB_PACKAGES_PATH" = "NVIDIA_ARCHIVE" ]; then
+        apt update
+        apt download nvidia-l4t-core nvidia-l4t-cuda
+        debian_packages=$(find . -name "nvidia-l4t*.deb")
+      elif [ -d $L4T_DEB_PACKAGES_PATH ]; then
+        debian_packages="$(find $L4T_DEB_PACKAGES_PATH\
+        -name "nvidia-l4t-core_*.deb" -o\
+        -name "nvidia-l4t-cuda_*.deb")"
+      fi
+      if [[ ! -z $debian_packages ]]; then
+        readarray -t <<<$debian_packages
+        for f in "${MAPFILE[@]}"
+        do
+          echo "extracting: $f..."
+          dpkg -x $f $CRAFT_PART_INSTALL/
+        done
+      fi
+      craftctl default
     stage-packages:
-      - nvidia-l4t-cuda
       - cudnn
       - libcudnn9-samples
       - libfreeimage3

--- a/multimedia/snap/snapcraft.yaml
+++ b/multimedia/snap/snapcraft.yaml
@@ -95,10 +95,11 @@ parts:
         apt download nvidia-l4t-camera nvidia-l4t-gstreamer nvidia-l4t-3d-core nvidia-l4t-multimedia
         debian_packages=$(find . -name "nvidia-l4t*.deb")
       elif [ -d $L4T_DEB_PACKAGES_PATH ]; then
-        debian_packages="$(find $L4T_DEB_PACKAGES_PATH -name "nvidia-l4t-camera_*.deb")"
-        debian_packages="$debian_packages $(find $L4T_DEB_PACKAGES_PATH -name "nvidia-l4t-gstreamer_*.deb")"
-        debian_packages="$debian_packages $(find $L4T_DEB_PACKAGES_PATH -name "nvidia-l4t-3d-core_*.deb")"
-        debian_packages="$debian_packages $(find $L4T_DEB_PACKAGES_PATH -name "nvidia-l4t-multimedia_*.deb")"
+        debian_packages="$(find $L4T_DEB_PACKAGES_PATH\
+        -name "nvidia-l4t-camera_*.deb" -o\
+        -name "nvidia-l4t-gstreamer_*.deb" -o\
+        -name "nvidia-l4t-3d-core_*.deb" -o\
+        -name "nvidia-l4t-multimedia_*.deb")"
       fi
       if [[ ! -z $debian_packages ]]; then
         readarray -t <<<$debian_packages

--- a/multimedia/snap/snapcraft.yaml
+++ b/multimedia/snap/snapcraft.yaml
@@ -88,11 +88,28 @@ apps:
 parts:
   camera:
     plugin: nil
+    override-stage: |
+      L4T_DEB_PACKAGES_PATH=${L4T_DEB_PACKAGES_PATH:="NVIDIA_ARCHIVE"}
+      if [ "$L4T_DEB_PACKAGES_PATH" = "NVIDIA_ARCHIVE" ]; then
+        apt update
+        apt download nvidia-l4t-camera nvidia-l4t-gstreamer nvidia-l4t-3d-core nvidia-l4t-multimedia
+        debian_packages=$(find . -name "nvidia-l4t*.deb")
+      elif [ -d $L4T_DEB_PACKAGES_PATH ]; then
+        debian_packages="$(find $L4T_DEB_PACKAGES_PATH -name "nvidia-l4t-camera_*.deb")"
+        debian_packages="$debian_packages $(find $L4T_DEB_PACKAGES_PATH -name "nvidia-l4t-gstreamer_*.deb")"
+        debian_packages="$debian_packages $(find $L4T_DEB_PACKAGES_PATH -name "nvidia-l4t-3d-core_*.deb")"
+        debian_packages="$debian_packages $(find $L4T_DEB_PACKAGES_PATH -name "nvidia-l4t-multimedia_*.deb")"
+      fi
+      if [[ ! -z $debian_packages ]]; then
+        readarray -t <<<$debian_packages
+        for f in "${MAPFILE[@]}"
+        do
+          echo "extracting: $f..."
+          dpkg -x $f $CRAFT_PART_INSTALL/
+        done
+      fi
+      craftctl default
     stage-packages:
-      - nvidia-l4t-camera
-      - nvidia-l4t-gstreamer
-      - nvidia-l4t-3d-core
-      - nvidia-l4t-multimedia
       - v4l-utils
       - gstreamer1.0-tools
       - gstreamer1.0-alsa

--- a/multimedia/snap/snapcraft.yaml
+++ b/multimedia/snap/snapcraft.yaml
@@ -93,12 +93,17 @@ parts:
       if [ "$L4T_DEB_PACKAGES_PATH" = "NVIDIA_ARCHIVE" ]; then
         apt update
         apt download nvidia-l4t-camera nvidia-l4t-gstreamer nvidia-l4t-3d-core nvidia-l4t-multimedia
+        apt download nvidia-l4t-core nvidia-l4t-multimedia-utils nvidia-l4t-cuda nvidia-l4t-nvsci
         debian_packages=$(find . -name "nvidia-l4t*.deb")
       elif [ -d $L4T_DEB_PACKAGES_PATH ]; then
         debian_packages="$(find $L4T_DEB_PACKAGES_PATH\
+        -name "nvidia-l4t-core_*.deb" -o\
         -name "nvidia-l4t-camera_*.deb" -o\
         -name "nvidia-l4t-gstreamer_*.deb" -o\
         -name "nvidia-l4t-3d-core_*.deb" -o\
+        -name "nvidia-l4t-nvsci_*.deb" -o\
+        -name "nvidia-l4t-cuda_*.deb" -o\
+        -name "nvidia-l4t-multimedia-utils_*.deb" -o\
         -name "nvidia-l4t-multimedia_*.deb")"
       fi
       if [[ ! -z $debian_packages ]]; then

--- a/nvidia-tegra-runtime/snap/snapcraft.yaml
+++ b/nvidia-tegra-runtime/snap/snapcraft.yaml
@@ -90,8 +90,6 @@ parts:
         done
       fi
       craftctl default
-    stage-packages:
-
 
   scripts:
     plugin: dump

--- a/nvidia-tegra-runtime/snap/snapcraft.yaml
+++ b/nvidia-tegra-runtime/snap/snapcraft.yaml
@@ -63,23 +63,23 @@ parts:
         debian_packages=$(find . -name "nvidia-l4t*.deb")
       elif [ -d $L4T_DEB_PACKAGES_PATH ]; then
         debian_packages="$(find $L4T_DEB_PACKAGES_PATH\
-        -name nvidia-l4t-weston_*.deb" -o\
-        -name nvidia-l4t-firmware_*.deb" -o\
-        -name nvidia-l4t-wayland_*.deb" -o\
-        -name nvidia-l4t-libwayland-egl1_*.deb" -o\
-        -name nvidia-l4t-libwayland-client0_*.deb" -o\
-        -name nvidia-l4t-libwayland-cursor0_*.deb" -o\
-        -name nvidia-l4t-libwayland-server0_*.deb" -o\
-        -name nvidia-l4t-nvml_*.deb" -o\
-        -name nvidia-l4t-cuda_*.deb" -o\
-        -name nvidia-l4t-dla-compiler_*.deb" -o\
-        -name nvidia-l4t-graphics-demos_*.deb" -o\
-        -name nvidia-l4t-3d-core_*.deb" -o\
-        -name nvidia-l4t-core_*.deb" -o\
-        -name nvidia-l4t-init_*.deb" -o\
-        -name nvidia-l4t-gbm_*.deb" -o\
-        -name nvidia-l4t-multimedia-utils_*.deb" -o\
-        -name nvidia-l4t-x11_*.deb")"
+        -name "nvidia-l4t-weston_*.deb" -o\
+        -name "nvidia-l4t-firmware_*.deb" -o\
+        -name "nvidia-l4t-wayland_*.deb" -o\
+        -name "nvidia-l4t-libwayland-egl1_*.deb" -o\
+        -name "nvidia-l4t-libwayland-client0_*.deb" -o\
+        -name "nvidia-l4t-libwayland-cursor0_*.deb" -o\
+        -name "nvidia-l4t-libwayland-server0_*.deb" -o\
+        -name "nvidia-l4t-nvml_*.deb" -o\
+        -name "nvidia-l4t-cuda_*.deb" -o\
+        -name "nvidia-l4t-dla-compiler_*.deb" -o\
+        -name "nvidia-l4t-graphics-demos_*.deb" -o\
+        -name "nvidia-l4t-3d-core_*.deb" -o\
+        -name "nvidia-l4t-core_*.deb" -o\
+        -name "nvidia-l4t-init_*.deb" -o\
+        -name "nvidia-l4t-gbm_*.deb" -o\
+        -name "nvidia-l4t-multimedia-utils_*.deb" -o\
+        -name "nvidia-l4t-x11_*.deb")"
       fi
       if [[ ! -z $debian_packages ]]; then
         readarray -t <<<$debian_packages

--- a/nvidia-tegra-runtime/snap/snapcraft.yaml
+++ b/nvidia-tegra-runtime/snap/snapcraft.yaml
@@ -38,11 +38,60 @@ parts:
     # See 'snapcraft plugins'
     plugin: nil
     source: .
+    override-stage: |
+      L4T_DEB_PACKAGES_PATH=${L4T_DEB_PACKAGES_PATH:="NVIDIA_ARCHIVE"}
+      if [ "$L4T_DEB_PACKAGES_PATH" = "NVIDIA_ARCHIVE" ]; then
+        apt update
+        apt download \
+          nvidia-l4t-weston \
+          nvidia-l4t-firmware \
+          nvidia-l4t-wayland \
+          nvidia-l4t-libwayland-egl1 \
+          nvidia-l4t-libwayland-client0 \
+          nvidia-l4t-libwayland-cursor0 \
+          nvidia-l4t-libwayland-server0 \
+          nvidia-l4t-nvml \
+          nvidia-l4t-cuda \
+          nvidia-l4t-dla-compiler \
+          nvidia-l4t-graphics-demos \
+          nvidia-l4t-3d-core \
+          nvidia-l4t-core \
+          nvidia-l4t-init \
+          nvidia-l4t-gbm \
+          nvidia-l4t-multimedia-utils \
+          nvidia-l4t-x11
+        debian_packages=$(find . -name "nvidia-l4t*.deb")
+      elif [ -d $L4T_DEB_PACKAGES_PATH ]; then
+        debian_packages="$(find $L4T_DEB_PACKAGES_PATH\
+        -name nvidia-l4t-weston_*.deb" -o\
+        -name nvidia-l4t-firmware_*.deb" -o\
+        -name nvidia-l4t-wayland_*.deb" -o\
+        -name nvidia-l4t-libwayland-egl1_*.deb" -o\
+        -name nvidia-l4t-libwayland-client0_*.deb" -o\
+        -name nvidia-l4t-libwayland-cursor0_*.deb" -o\
+        -name nvidia-l4t-libwayland-server0_*.deb" -o\
+        -name nvidia-l4t-nvml_*.deb" -o\
+        -name nvidia-l4t-cuda_*.deb" -o\
+        -name nvidia-l4t-dla-compiler_*.deb" -o\
+        -name nvidia-l4t-graphics-demos_*.deb" -o\
+        -name nvidia-l4t-3d-core_*.deb" -o\
+        -name nvidia-l4t-core_*.deb" -o\
+        -name nvidia-l4t-init_*.deb" -o\
+        -name nvidia-l4t-gbm_*.deb" -o\
+        -name nvidia-l4t-multimedia-utils_*.deb" -o\
+        -name nvidia-l4t-x11_*.deb")"
+      fi
+      if [[ ! -z $debian_packages ]]; then
+        readarray -t <<<$debian_packages
+        for f in "${MAPFILE[@]}"
+        do
+          echo "extracting: $f..."
+          dpkg -x $f $CRAFT_PART_INSTALL/
+        done
+      fi
+      craftctl default
     stage-packages:
-      - nvidia-l4t-nvml
-      - nvidia-l4t-cuda
-      - nvidia-l4t-dla-compiler
-      - nvidia-l4t-graphics-demos
+
 
   scripts:
     plugin: dump

--- a/nvpmodel/snap/snapcraft.yaml
+++ b/nvpmodel/snap/snapcraft.yaml
@@ -114,7 +114,10 @@ parts:
         apt download nvidia-l4t-nvpmodel nvidia-l4t-core nvidia-l4t-tools nvidia-l4t-init
         debian_packages=$(find . -name "nvidia-l4t*.deb")
       elif [ -d $L4T_DEB_PACKAGES_PATH ]; then
-        debian_packages=$(find $L4T_DEB_PACKAGES_PATH -name "nvidia-l4t*.deb")
+        debian_packages="$(find $L4T_DEB_PACKAGES_PATH -name "nvidia-l4t-nvpmodel_*.deb")"
+        debian_packages="$debian_packages $(find $L4T_DEB_PACKAGES_PATH -name "nvidia-l4t-core_*.deb")"
+        debian_packages="$debian_packages $(find $L4T_DEB_PACKAGES_PATH -name "nvidia-l4t-tools_*.deb")"
+        debian_packages="$debian_packages $(find $L4T_DEB_PACKAGES_PATH -name "nvidia-l4t-init_*.deb")"
       fi
       if [[ ! -z $debian_packages ]]; then
         readarray -t <<<$debian_packages

--- a/nvpmodel/snap/snapcraft.yaml
+++ b/nvpmodel/snap/snapcraft.yaml
@@ -107,10 +107,25 @@ apps:
 parts:
   nvpmodel:
     plugin: nil
+    override-stage: |
+      L4T_DEB_PACKAGES_PATH=${L4T_DEB_PACKAGES_PATH:="NVIDIA_ARCHIVE"}
+      if [ "$L4T_DEB_PACKAGES_PATH" = "NVIDIA_ARCHIVE" ]; then
+        apt update
+        apt download nvidia-l4t-nvpmodel nvidia-l4t-core nvidia-l4t-tools nvidia-l4t-init
+        debian_packages=$(find . -name "nvidia-l4t*.deb")
+      elif [ -d $L4T_DEB_PACKAGES_PATH ]; then
+        debian_packages=$(find $L4T_DEB_PACKAGES_PATH -name "nvidia-l4t*.deb")
+      fi
+      if [[ ! -z $debian_packages ]]; then
+        readarray -t <<<$debian_packages
+        for f in "${MAPFILE[@]}"
+        do
+          echo "extracting: $f..."
+          dpkg -x $f $CRAFT_PART_INSTALL/
+        done
+      fi
+      craftctl default
     stage-packages:
-      - nvidia-l4t-nvpmodel
-      - nvidia-l4t-core
-      - nvidia-l4t-tools
       - coreutils
       - systemd
       - bc

--- a/nvpmodel/snap/snapcraft.yaml
+++ b/nvpmodel/snap/snapcraft.yaml
@@ -114,10 +114,11 @@ parts:
         apt download nvidia-l4t-nvpmodel nvidia-l4t-core nvidia-l4t-tools nvidia-l4t-init
         debian_packages=$(find . -name "nvidia-l4t*.deb")
       elif [ -d $L4T_DEB_PACKAGES_PATH ]; then
-        debian_packages="$(find $L4T_DEB_PACKAGES_PATH -name "nvidia-l4t-nvpmodel_*.deb")"
-        debian_packages="$debian_packages $(find $L4T_DEB_PACKAGES_PATH -name "nvidia-l4t-core_*.deb")"
-        debian_packages="$debian_packages $(find $L4T_DEB_PACKAGES_PATH -name "nvidia-l4t-tools_*.deb")"
-        debian_packages="$debian_packages $(find $L4T_DEB_PACKAGES_PATH -name "nvidia-l4t-init_*.deb")"
+        debian_packages="$(find $L4T_DEB_PACKAGES_PATH\
+        -name "nvidia-l4t-nvpmodel_*.deb" -o\
+        -name "nvidia-l4t-core_*.deb" -o\
+        -name "nvidia-l4t-tools_*.deb" -o\
+        -name "nvidia-l4t-init_*.deb")"
       fi
       if [[ ! -z $debian_packages ]]; then
         readarray -t <<<$debian_packages

--- a/tensorrt-samples/snap/snapcraft.yaml
+++ b/tensorrt-samples/snap/snapcraft.yaml
@@ -58,12 +58,12 @@ parts:
       touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
       L4T_DEB_PACKAGES_PATH=${L4T_DEB_PACKAGES_PATH:="NVIDIA_ARCHIVE"}
       if [ "$L4T_DEB_PACKAGES_PATH" = "NVIDIA_ARCHIVE" ]; then
-        sudo apt-get update
-        sudo apt install --yes nvidia-l4t-dla-compiler nvidia-l4t-cuda
+        apt update
+        apt install --yes nvidia-l4t-dla-compiler nvidia-l4t-cuda
       elif [ -d $L4T_DEB_PACKAGES_PATH ]; then
-        sudo apt install -y libegl1 -f
-        sudo dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-cuda_*.deb
-        sudo dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-dla-compiler_*.deb
+        apt install --yes libegl1 -f
+        dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-cuda_*.deb
+        dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-dla-compiler_*.deb
       fi
       echo '/usr/local/cuda-12.6/compat' | tee -a /etc/ld.so.conf.d/000_cuda.conf
       ldconfig

--- a/tensorrt-samples/snap/snapcraft.yaml
+++ b/tensorrt-samples/snap/snapcraft.yaml
@@ -56,7 +56,15 @@ parts:
     override-build: |
       mkdir -p /opt/nvidia/l4t-packages/
       touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
-      apt install --yes nvidia-l4t-dla-compiler nvidia-l4t-cuda
+      L4T_DEB_PACKAGES_PATH=${L4T_DEB_PACKAGES_PATH:="NVIDIA_ARCHIVE"}
+      if [ "$L4T_DEB_PACKAGES_PATH" = "NVIDIA_ARCHIVE" ]; then
+        sudo apt-get update
+        sudo apt install --yes nvidia-l4t-dla-compiler nvidia-l4t-cuda
+      elif [ -d $L4T_DEB_PACKAGES_PATH ]; then
+        sudo apt install -y libegl1 -f
+        sudo dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-cuda_*.deb
+        sudo dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-dla-compiler_*.deb
+      fi
       echo '/usr/local/cuda-12.6/compat' | tee -a /etc/ld.so.conf.d/000_cuda.conf
       ldconfig
       cd $CRAFT_PART_INSTALL/usr/src/tensorrt/samples

--- a/vpi-runtime/bin/vpi-provider-wrapper
+++ b/vpi-runtime/bin/vpi-provider-wrapper
@@ -4,7 +4,7 @@ set -euo pipefail
 SELF="$( cd -- "$(dirname "$0")/.." ; pwd -P )"
 
 ARCH_TRIPLET="aarch64-linux-gnu"
-LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}${SELF}/opt/nvidia/vpi3/lib/${ARCH_TRIPLET}:${SELF}/lib/${ARCH_TRIPLET}:${SELF}/usr/lib/${ARCH_TRIPLET}:${SELF}/usr/lib/:${SELF}/usr/lib/${ARCH_TRIPLET}/nvidia
+LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}${SELF}/opt/nvidia/vpi3/lib/${ARCH_TRIPLET}:${SELF}/lib/${ARCH_TRIPLET}:${SELF}/usr/lib/${ARCH_TRIPLET}:${SELF}/usr/lib/:${SELF}/usr/lib/${ARCH_TRIPLET}/nvidia:${SELF}/usr/lib/${ARCH_TRIPLET}/tegra-egl
 
 export LD_LIBRARY_PATH
 

--- a/vpi-runtime/snap/snapcraft.yaml
+++ b/vpi-runtime/snap/snapcraft.yaml
@@ -35,12 +35,13 @@ parts:
       L4T_DEB_PACKAGES_PATH=${L4T_DEB_PACKAGES_PATH:="NVIDIA_ARCHIVE"}
       if [ "$L4T_DEB_PACKAGES_PATH" = "NVIDIA_ARCHIVE" ]; then
         apt update
-        apt download nvidia-l4t-core nvidia-l4t-cuda nvidia-l4t-nvsci nvidia-l4t-pva nvidia-l4t-multimedia nvidia-l4t-multimedia-utils
+        apt download nvidia-l4t-core nvidia-l4t-cuda nvidia-l4t-nvsci nvidia-l4t-pva nvidia-l4t-multimedia nvidia-l4t-multimedia-utils nvidia-l4t-3d-core
         debian_packages=$(find . -name "nvidia-l4t*.deb")
       elif [ -d $L4T_DEB_PACKAGES_PATH ]; then
         debian_packages="$(find $L4T_DEB_PACKAGES_PATH\
         -name "nvidia-l4t-core_*.deb" -o\
         -name "nvidia-l4t-cuda_*.deb" -o\
+        -name "nvidia-l4t-3d-core_*.deb" -o\
         -name "nvidia-l4t-nvsci_*.deb" -o\
         -name "nvidia-l4t-pva_*.deb" -o\
         -name "nvidia-l4t-multimedia_*.deb" -o\

--- a/vpi-runtime/snap/snapcraft.yaml
+++ b/vpi-runtime/snap/snapcraft.yaml
@@ -61,6 +61,7 @@ parts:
       - nvidia-vpi
       - libnvvpi3
       - python3.10-vpi3
+      - libegl1
     override-prime: |
       craftctl default
       rm -fr $CRAFT_PRIME/usr/share/icons

--- a/vpi-runtime/snap/snapcraft.yaml
+++ b/vpi-runtime/snap/snapcraft.yaml
@@ -31,14 +31,36 @@ package-repositories:
 parts:
   vpi-runtime:
     plugin: nil
+    override-stage: |
+      L4T_DEB_PACKAGES_PATH=${L4T_DEB_PACKAGES_PATH:="NVIDIA_ARCHIVE"}
+      if [ "$L4T_DEB_PACKAGES_PATH" = "NVIDIA_ARCHIVE" ]; then
+        apt update
+        apt download nvidia-l4t-core nvidia-l4t-cuda nvidia-l4t-nvsci nvidia-l4t-pva nvidia-l4t-multimedia nvidia-l4t-multimedia-utils
+        debian_packages=$(find . -name "nvidia-l4t*.deb")
+      elif [ -d $L4T_DEB_PACKAGES_PATH ]; then
+        debian_packages="$(find $L4T_DEB_PACKAGES_PATH\
+        -name "nvidia-l4t-core_*.deb" -o\
+        -name "nvidia-l4t-cuda_*.deb" -o\
+        -name "nvidia-l4t-nvsci_*.deb" -o\
+        -name "nvidia-l4t-pva_*.deb" -o\
+        -name "nvidia-l4t-multimedia_*.deb" -o\
+        -name "nvidia-l4t-multimedia-utils_*.deb")"
+      fi
+      if [[ ! -z $debian_packages ]]; then
+        readarray -t <<<$debian_packages
+        for f in "${MAPFILE[@]}"
+        do
+          echo "extracting: $f..."
+          dpkg -x $f $CRAFT_PART_INSTALL/
+        done
+      fi
+      craftctl default
     stage-packages:
       - libopencv
       - libopencv-python
       - nvidia-vpi
       - libnvvpi3
       - python3.10-vpi3
-      - nvidia-l4t-multimedia
-      - nvidia-l4t-pva
     override-prime: |
       craftctl default
       rm -fr $CRAFT_PRIME/usr/share/icons

--- a/vpi-samples/snap/snapcraft.yaml
+++ b/vpi-samples/snap/snapcraft.yaml
@@ -63,7 +63,27 @@ parts:
     override-build: |
       mkdir -p /opt/nvidia/l4t-packages/
       touch /opt/nvidia/l4t-packages/.nv-l4t-disable-boot-fw-update-in-preinstall
-      apt install --yes nvidia-l4t-pva nvidia-l4t-3d-core nvidia-l4t-multimedia
+      L4T_DEB_PACKAGES_PATH=${L4T_DEB_PACKAGES_PATH:="NVIDIA_ARCHIVE"}
+      if [ "$L4T_DEB_PACKAGES_PATH" = "NVIDIA_ARCHIVE" ]; then
+        apt update
+        apt install --yes nvidia-l4t-pva nvidia-l4t-3d-core nvidia-l4t-multimedia
+      elif [ -d $L4T_DEB_PACKAGES_PATH ]; then
+        apt install -y libegl1 nvme-cli efibootmgr bridge-utils libffi7 libasound2 libgles2 -f
+        apt install -y alsa-topology-conf alsa-ucm-conf libasound2-data libdrm-amdgpu1 -f
+        apt install -y libgstreamer-plugins-bad1.0-0 libllvm15 libvulkan1 mesa-vulkan-drivers -f
+        dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-core_*.deb
+        dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-firmware_*.deb
+        dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-init_*.deb
+        dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-libwayland-client0_*.deb
+        dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-libwayland-server0_*.deb
+        dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-nvsci_*.deb
+        dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-x11_*.deb
+        dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-pva_*.deb
+        dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-multimedia-utils_*.deb
+        dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-wayland_*.deb
+        dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-3d-core_*.deb
+        dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-multimedia_*.deb
+      fi
       export LD_LIBRARY_PATH=${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}/usr/lib/aarch64-linux-gnu/tegra-egl/
       cd $CRAFT_PART_INSTALL/opt/nvidia/vpi3/samples/
       for f in */CMakeLists.txt ; do pushd $(dirname $f) ; cmake -DOpenCV_DIR=/usr/lib/cmake/opencv4 . ; VERBOSE=1 make ; popd ; done

--- a/vpi-samples/snap/snapcraft.yaml
+++ b/vpi-samples/snap/snapcraft.yaml
@@ -71,8 +71,8 @@ parts:
         apt install -y libegl1 nvme-cli efibootmgr bridge-utils libffi7 libasound2 libgles2 -f
         apt install -y alsa-topology-conf alsa-ucm-conf libasound2-data libdrm-amdgpu1 -f
         apt install -y libgstreamer-plugins-bad1.0-0 libllvm15 libvulkan1 mesa-vulkan-drivers -f
-        dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-cuda_*.deb
         dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-core_*.deb
+        dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-cuda_*.deb
         dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-firmware_*.deb
         dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-init_*.deb
         dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-libwayland-client0_*.deb

--- a/vpi-samples/snap/snapcraft.yaml
+++ b/vpi-samples/snap/snapcraft.yaml
@@ -66,11 +66,12 @@ parts:
       L4T_DEB_PACKAGES_PATH=${L4T_DEB_PACKAGES_PATH:="NVIDIA_ARCHIVE"}
       if [ "$L4T_DEB_PACKAGES_PATH" = "NVIDIA_ARCHIVE" ]; then
         apt update
-        apt install --yes nvidia-l4t-pva nvidia-l4t-3d-core nvidia-l4t-multimedia
+        apt install --yes nvidia-l4t-cuda nvidia-l4t-pva nvidia-l4t-3d-core nvidia-l4t-multimedia
       elif [ -d $L4T_DEB_PACKAGES_PATH ]; then
         apt install -y libegl1 nvme-cli efibootmgr bridge-utils libffi7 libasound2 libgles2 -f
         apt install -y alsa-topology-conf alsa-ucm-conf libasound2-data libdrm-amdgpu1 -f
         apt install -y libgstreamer-plugins-bad1.0-0 libllvm15 libvulkan1 mesa-vulkan-drivers -f
+        dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-cuda_*.deb
         dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-core_*.deb
         dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-firmware_*.deb
         dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-init_*.deb


### PR DESCRIPTION
Implement a mechanism for each `snapcraft` recipe to read the `L4T_DEB_PACKAGES_PATH` environment variable, if it is defined `snapcraft` will look for specific L4T Debian files located in the machine where the snaps are built, and will use those as build/stage packages as needed to build the corresponding snaps.

When the `L4T_DEB_PACKAGES_PATH` environment variable is not defined, `snapcraft` will take each Debian package from the Nvidia Archive through the `package-repositories`.

Since now Debian packages are selected through this mechanism there are used the `override-stage` and `override-build` steps to manage the corresponding packages as needed.

