### PR TITLE
Nvidia Tegra Runtime: Add the necessary L4T packages for the riversde-core-container/iGPU to succeed

### DIFF
--- a/nvidia-tegra-runtime/snap/snapcraft.yaml
+++ b/nvidia-tegra-runtime/snap/snapcraft.yaml
@@ -59,6 +59,11 @@ parts:
           nvidia-l4t-init \
           nvidia-l4t-gbm \
           nvidia-l4t-multimedia-utils \
+          nvidia-l4t-multimedia \
+          nvidia-l4t-gstreamer \
+          nvidia-l4t-camera \
+          nvidia-l4t-pva \
+          nvidia-l4t-nvsci \
           nvidia-l4t-x11
         debian_packages=$(find . -name "nvidia-l4t*.deb")
       elif [ -d $L4T_DEB_PACKAGES_PATH ]; then
@@ -79,6 +84,11 @@ parts:
         -name "nvidia-l4t-init_*.deb" -o\
         -name "nvidia-l4t-gbm_*.deb" -o\
         -name "nvidia-l4t-multimedia-utils_*.deb" -o\
+        -name "nvidia-l4t-multimedia_*.deb" -o\
+        -name "nvidia-l4t-gstreamer_*.deb" -o\
+        -name "nvidia-l4t-camera_*.deb" -o\
+        -name "nvidia-l4t-pva_*.deb" -o\
+        -name "nvidia-l4t-nvsci_*.deb" -o\
         -name "nvidia-l4t-x11_*.deb")"
       fi
       if [[ ! -z $debian_packages ]]; then


### PR DESCRIPTION
 The required libraries are provided by the packages listed below.
  * libgstnvegl provided by nvidia-l4t-gstreamer.
  * libnvargus provided by nvidia-l4t-camera.
  * libnvbufsurftransform provided by nvidia-l4t-multimedia.
  * libnvpvaintf provided by nvidia-l4t-pva.
  * libnvscibuf provided by nvidia-l4t-nvsciz.