### PR TITLE
Debug runtime issues with graphics core22

### DIFF
--- a/vpi-samples/bin/graphics-core22-wrapper
+++ b/vpi-samples/bin/graphics-core22-wrapper
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec "${SNAP}/graphics/bin/graphics-core22-provider-wrapper" "$@"

--- a/vpi-samples/snap/snapcraft.yaml
+++ b/vpi-samples/snap/snapcraft.yaml
@@ -91,7 +91,7 @@ parts:
     override-prime: |
       craftctl default
       rm -fr $CRAFT_PRIME/usr/share/icons
-  vpi-wrapper:
+  vpi-wrappers:
     after: [vpi-samples]
     source: .
     plugin: dump
@@ -99,6 +99,7 @@ parts:
       '*': bin/
     prime:
     - bin/vpi-wrapper
+    - bin/graphics-core22-wrapper
 
 apps:
   vpi-sample-01-convolve-2d:

--- a/vpi-samples/snap/snapcraft.yaml
+++ b/vpi-samples/snap/snapcraft.yaml
@@ -14,7 +14,6 @@ plugs:
   graphics-core22:
     interface: content
     target: $SNAP/graphics
-    default-provider: mesa-core22 ## note: expecting the nvidia-tegra-runtime
   vpi3-core22:
     interface: content
     target: $SNAP/vpi
@@ -92,17 +91,6 @@ parts:
     override-prime: |
       craftctl default
       rm -fr $CRAFT_PRIME/usr/share/icons
-  graphics-core22:
-    after: [vpi-samples]
-    source: https://github.com/canonical/gpu-snap.git
-    plugin: dump
-    override-prime: |
-      craftctl default
-      for filelist in /var/lib/dpkg/info/nvidia-*.list ; do for f in $(cat $filelist | awk "/.+/ { print  \"${CRAFT_PRIME}/\" \$0 }") ; do test -f $f && rm $f ; done ; done
-      rm -fr ${CRAFT_PRIME}/lib/firmware
-      ${CRAFT_PART_SRC}/bin/graphics-core22-cleanup mesa-core22 nvidia-core22
-    prime:
-    - bin/graphics-core22-wrapper
   vpi-wrapper:
     after: [vpi-samples]
     source: .


### PR DESCRIPTION
When the VPI-samples snap was installed before other `graphics-core22` dependent snaps; all the `graphics-core22` connections were done to `mesa-core22` and some `nvidia-tegra-runtime` libraries were not located producing runtime errors. This Pull Request modifies the VPI-samples snap to consume  `graphics-core22`  as done in the CUDA-samples/Tensor RT-samples snap to prevent the previously described errors.

This PR fixes the following issues:
* Issues with CUDA-samples: `cudaErrorInsufficientDriver`.
* VPI samples: `VPI_ERROR_INTERNAL: (EGL_NOT_INITIALIZED)` 

The VPI-samples snap still have the following known issues when running the corresponding test cases, these issues should be addressed from the Jenkins/Checkbox perspective.

* `VPI_ERROR_INTERNAL: (EGL_BAD_ALLOC) Failed to get EGL display` This issue only occurs when running the `checkbox` test-cases remotely (via `Jenkins/testflinger`) , it is caused because the `DISPLAY=:0` environment variable is exported by the `checkbox-core.conf` launcher in our Jenkins Jobs.

* `VPI_ERROR_INTERNAL: PVA kernel not loaded due to internal authentication or other PVA driver error (possibly out of memory)` This issue is related to PVA authentication, and as per the Nvidia website the following command can be used to disable PVA authentication and run the corresponding jobs, this command can be included in our `checkbox` jobs.
  ```
  sudo bash -c 'echo 0 > /sys/kernel/debug/pva0/vpu_app_authentication'
  ```

  

  