### PR TITLE
Install the nvidia-l4t-dla-compiler package through the Nvidia archive

### DIFF
--- a/nvidia-tegra-runtime/snap/snapcraft.yaml
+++ b/nvidia-tegra-runtime/snap/snapcraft.yaml
@@ -72,7 +72,6 @@ parts:
         -name "nvidia-l4t-libwayland-server0_*.deb" -o\
         -name "nvidia-l4t-nvml_*.deb" -o\
         -name "nvidia-l4t-cuda_*.deb" -o\
-        -name "nvidia-l4t-dla-compiler_*.deb" -o\
         -name "nvidia-l4t-graphics-demos_*.deb" -o\
         -name "nvidia-l4t-3d-core_*.deb" -o\
         -name "nvidia-l4t-core_*.deb" -o\
@@ -80,6 +79,11 @@ parts:
         -name "nvidia-l4t-gbm_*.deb" -o\
         -name "nvidia-l4t-multimedia-utils_*.deb" -o\
         -name "nvidia-l4t-x11_*.deb")"
+        # nvidia-l4t-dla-compiler is not part of the private set of Nvidia packages,
+        # that's why it is installed through the Nvidia archive.
+        apt update
+        apt download nvidia-l4t-dla-compiler
+        debian_packages="$debian_packages"$'\n'"$(find . -name "nvidia-l4t-dla-compiler*.deb")"
       fi
       if [[ ! -z $debian_packages ]]; then
         readarray -t <<<$debian_packages

--- a/tensorrt-samples/snap/snapcraft.yaml
+++ b/tensorrt-samples/snap/snapcraft.yaml
@@ -63,7 +63,9 @@ parts:
       elif [ -d $L4T_DEB_PACKAGES_PATH ]; then
         apt install --yes libegl1 -f
         dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-cuda_*.deb
-        dpkg -i $L4T_DEB_PACKAGES_PATH/nvidia-l4t-dla-compiler_*.deb
+        # nvidia-l4t-dla-compiler is not part of the private set of Nvidia packages,
+        # that's why it is installed through the Nvidia archive.
+        apt install --yes nvidia-l4t-dla-compiler
       fi
       echo '/usr/local/cuda-12.6/compat' | tee -a /etc/ld.so.conf.d/000_cuda.conf
       ldconfig


### PR DESCRIPTION
The `nvidia-l4t-dla-compiler` package is maintained by another team of Nvidia developers and not part of the BSP.

So this package is not expected to be stored into our OEM-share server (i.e., `riverside/test-snaps/ea/nvidia-l4t-packages/`) however, this package is necessary to build and run the Tensor RT samples, so the snapcraft recipes were modified for it it to always be downloaded from the Nvidia archive and used as a build/stage package by the corresponding Tegra snaps.