### PR TITLE
Use r36.5 as a base for all snaps

### DIFF
--- a/cuda-samples/snap/snapcraft.yaml
+++ b/cuda-samples/snap/snapcraft.yaml
@@ -12,14 +12,14 @@ confinement: strict # use 'strict' once you have the right plugs and slots
 package-repositories:
   - type: apt
     components: [main]
-    suites: [r36.4]
+    suites: [r36.5]
     key-id: 3C6D1FF3100C8C3ABB0869C0E6543461A9996195
     key-server: https://repo.download.nvidia.com/jetson/jetson-ota-public.asc
     url: https://repo.download.nvidia.com/jetson/t234
     architectures: [arm64]
   - type: apt
     components: [main]
-    suites: [r36.4]
+    suites: [r36.5]
     key-id: 3C6D1FF3100C8C3ABB0869C0E6543461A9996195
     key-server: https://repo.download.nvidia.com/jetson/jetson-ota-public.asc
     url: https://repo.download.nvidia.com/jetson/common

--- a/cudnn-samples/snap/snapcraft.yaml
+++ b/cudnn-samples/snap/snapcraft.yaml
@@ -11,14 +11,14 @@ base: core22
 package-repositories:
   - type: apt
     components: [main]
-    suites: [r36.4]
+    suites: [r36.5]
     key-id: 3C6D1FF3100C8C3ABB0869C0E6543461A9996195
     key-server: https://repo.download.nvidia.com/jetson/jetson-ota-public.asc
     url: https://repo.download.nvidia.com/jetson/t234
     architectures: [arm64]
   - type: apt
     components: [main]
-    suites: [r36.4]
+    suites: [r36.5]
     key-id: 3C6D1FF3100C8C3ABB0869C0E6543461A9996195
     key-server: https://repo.download.nvidia.com/jetson/jetson-ota-public.asc
     url: https://repo.download.nvidia.com/jetson/common

--- a/multimedia/snap/snapcraft.yaml
+++ b/multimedia/snap/snapcraft.yaml
@@ -11,14 +11,14 @@ base: core22
 package-repositories:
   - type: apt
     components: [main]
-    suites: [r36.4]
+    suites: [r36.5]
     key-id: 3C6D1FF3100C8C3ABB0869C0E6543461A9996195
     key-server: https://repo.download.nvidia.com/jetson/jetson-ota-public.asc
     url: https://repo.download.nvidia.com/jetson/t234
     architectures: [arm64]
   - type: apt
     components: [main]
-    suites: [r36.4]
+    suites: [r36.5]
     key-id: 3C6D1FF3100C8C3ABB0869C0E6543461A9996195
     key-server: https://repo.download.nvidia.com/jetson/jetson-ota-public.asc
     url: https://repo.download.nvidia.com/jetson/common

--- a/nvidia-tegra-runtime/snap/snapcraft.yaml
+++ b/nvidia-tegra-runtime/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: nvidia-tegra-runtime # you probably want to 'snapcraft register <name>'
 base: core22 # the base snap is the execution environment for this snap
-version: '36.4' # just for humans, typically '1.2+git' or '1.3.2'
+version: '36.5' # just for humans, typically '1.2+git' or '1.3.2'
 summary: NVIDIA Tegra firmware and core files for Jetson and IGX ORIN boards (arm64) # 79 char long summary
 description: |
   Install all necessary files to run CUDA toolkit on Ubuntu image

--- a/nvidia-tegra-runtime/snap/snapcraft.yaml
+++ b/nvidia-tegra-runtime/snap/snapcraft.yaml
@@ -20,14 +20,14 @@ apps:
 package-repositories:
   - type: apt
     components: [main]
-    suites: [r36.4]
+    suites: [r36.5]
     key-id: 3C6D1FF3100C8C3ABB0869C0E6543461A9996195
     key-server: https://repo.download.nvidia.com/jetson/jetson-ota-public.asc
     url: https://repo.download.nvidia.com/jetson/t234
     architectures: [arm64]
   - type: apt
     components: [main]
-    suites: [r36.4]
+    suites: [r36.5]
     key-id: 3C6D1FF3100C8C3ABB0869C0E6543461A9996195
     key-server: https://repo.download.nvidia.com/jetson/jetson-ota-public.asc
     url: https://repo.download.nvidia.com/jetson/common

--- a/nvpmodel/snap/snapcraft.yaml
+++ b/nvpmodel/snap/snapcraft.yaml
@@ -11,14 +11,14 @@ base: core22
 package-repositories:
   - type: apt
     components: [main]
-    suites: [r36.4]
+    suites: [r36.5]
     key-id: 3C6D1FF3100C8C3ABB0869C0E6543461A9996195
     key-server: https://repo.download.nvidia.com/jetson/jetson-ota-public.asc
     url: https://repo.download.nvidia.com/jetson/t234
     architectures: [arm64]
   - type: apt
     components: [main]
-    suites: [r36.4]
+    suites: [r36.5]
     key-id: 3C6D1FF3100C8C3ABB0869C0E6543461A9996195
     key-server: https://repo.download.nvidia.com/jetson/jetson-ota-public.asc
     url: https://repo.download.nvidia.com/jetson/common

--- a/tensorrt-libs/snap/snapcraft.yaml
+++ b/tensorrt-libs/snap/snapcraft.yaml
@@ -14,14 +14,14 @@ confinement: strict # use 'strict' once you have the right plugs and slots
 package-repositories:
   - type: apt
     components: [main]
-    suites: [r36.4]
+    suites: [r36.5]
     key-id: 3C6D1FF3100C8C3ABB0869C0E6543461A9996195
     key-server: https://repo.download.nvidia.com/jetson/jetson-ota-public.asc
     url: https://repo.download.nvidia.com/jetson/t234
     architectures: [arm64]
   - type: apt
     components: [main]
-    suites: [r36.4]
+    suites: [r36.5]
     key-id: 3C6D1FF3100C8C3ABB0869C0E6543461A9996195
     key-server: https://repo.download.nvidia.com/jetson/jetson-ota-public.asc
     url: https://repo.download.nvidia.com/jetson/common

--- a/tensorrt-samples/snap/snapcraft.yaml
+++ b/tensorrt-samples/snap/snapcraft.yaml
@@ -11,14 +11,14 @@ confinement: strict # use 'strict' once you have the right plugs and slots
 package-repositories:
   - type: apt
     components: [main]
-    suites: [r36.4]
+    suites: [r36.5]
     key-id: 3C6D1FF3100C8C3ABB0869C0E6543461A9996195
     key-server: https://repo.download.nvidia.com/jetson/jetson-ota-public.asc
     url: https://repo.download.nvidia.com/jetson/t234
     architectures: [arm64]
   - type: apt
     components: [main]
-    suites: [r36.4]
+    suites: [r36.5]
     key-id: 3C6D1FF3100C8C3ABB0869C0E6543461A9996195
     key-server: https://repo.download.nvidia.com/jetson/jetson-ota-public.asc
     url: https://repo.download.nvidia.com/jetson/common

--- a/vpi-runtime/snap/snapcraft.yaml
+++ b/vpi-runtime/snap/snapcraft.yaml
@@ -13,14 +13,14 @@ confinement: strict
 package-repositories:
   - type: apt
     components: [main]
-    suites: [r36.4]
+    suites: [r36.5]
     key-id: 3C6D1FF3100C8C3ABB0869C0E6543461A9996195
     key-server: https://repo.download.nvidia.com/jetson/jetson-ota-public.asc
     url: https://repo.download.nvidia.com/jetson/t234
     architectures: [arm64]
   - type: apt
     components: [main]
-    suites: [r36.4]
+    suites: [r36.5]
     key-id: 3C6D1FF3100C8C3ABB0869C0E6543461A9996195
     key-server: https://repo.download.nvidia.com/jetson/jetson-ota-public.asc
     url: https://repo.download.nvidia.com/jetson/common

--- a/vpi-samples/snap/snapcraft.yaml
+++ b/vpi-samples/snap/snapcraft.yaml
@@ -21,14 +21,14 @@ plugs:
 package-repositories:
   - type: apt
     components: [main]
-    suites: [r36.4]
+    suites: [r36.5]
     key-id: 3C6D1FF3100C8C3ABB0869C0E6543461A9996195
     key-server: https://repo.download.nvidia.com/jetson/jetson-ota-public.asc
     url: https://repo.download.nvidia.com/jetson/t234
     architectures: [arm64]
   - type: apt
     components: [main]
-    suites: [r36.4]
+    suites: [r36.5]
     key-id: 3C6D1FF3100C8C3ABB0869C0E6543461A9996195
     key-server: https://repo.download.nvidia.com/jetson/jetson-ota-public.asc
     url: https://repo.download.nvidia.com/jetson/common


### PR DESCRIPTION
- Update all snaps to use r36.5
    
    In order to download all nvidia-l4t packages aligned with r36.5, we need
    to change the `suites` part of the package repository to r36.5.

- nvidia-tegra-runtime: bump version to 36.5