### PR TITLE
Fix: Disable setup_actmon on the nvpower script

### DIFF
--- a/nvpmodel/snap/snapcraft.yaml
+++ b/nvpmodel/snap/snapcraft.yaml
@@ -129,6 +129,7 @@ parts:
         done
       fi
       craftctl default
+      sed -i 's/^setup_actmon/#setup_actmon/' $CRAFT_STAGE/etc/systemd/nvpower.sh
     stage-packages:
       - coreutils
       - systemd


### PR DESCRIPTION
## Description

The `/etc/systemd/nvpower.sh` script provided by the Nvpmodel package contains the `setup_actmon` function, which does the following.

```
function setup_actmon()
{
    debugfs_actmon="/sys/kernel/debug/tegra-host1x/actmon"

    # Sets how often the system checks activity.
    tee ${debugfs_actmon}/*/sample_period 1>/dev/null <<< 1500

    # Forces the system to wait for 7 "busy" checks before speeding up the memory 
    tee ${debugfs_actmon}/*/module0/consec_upper_num 1>/dev/null <<< 7

    # Forces the system to wait for 7 "idle" checks before slowing down the memory 
    tee ${debugfs_actmon}/*/module0/consec_lower_num 1>/dev/null <<< 7

    # Acts as a "multiplier" to make the frequency boost stronger once it finally triggers.
    tee ${debugfs_actmon}/*/module0/k 1>/dev/null <<< 2
}
```
However, when having Secure Boot enabled the device will enter [Integrity Lock-down mode](https://documentation.ubuntu.com/security/security-features/kernel-protections/#kernel-lockdown) preventing the snap to access debug file systems (i.e., `/sys/kernel/debug`), it is important to say that the sys-file-systems remain accessible.

A temporary workaround is to avoid the `setup_actmon` initialization, by commenting out the function call from the `/etc/systemd/nvpower.sh` script, however these settings tune the "aggressiveness" of the power-saving algorithm. So we should determine an better long term approach.

## Resolved issues

https://warthogs.atlassian.net/browse/PERI-1399

## Tests

1. The Nvpmodel snap was built locally, on a device running UC22 + Secure boot enabled, this log shows that the `nvpower` service could be initialized [custom-snap-init.txt](https://github.com/user-attachments/files/27380520/custom-snap-init.txt).
2. The Nvpmodel Checkbox test cases were successfully executed on the `nvidia-jetson-orin-nano-c35887` Running UC22 + Secure boot [submission_2026-05-04T23.39.15.739434.zip](https://github.com/user-attachments/files/27380529/submission_2026-05-04T23.39.15.739434.zip).
3. **This is still a Draft**, we need to run additional testing.
