### PR TITLE
multimedia: add home and var-tmp plugs for artifact writes

### DIFF
--- a/multimedia/README.md
+++ b/multimedia/README.md
@@ -24,6 +24,8 @@ $ sudo snap connect multimedia:kernel-module-observe
 $ sudo snap connect multimedia:media-control
 $ sudo snap connect multimedia:process-control
 $ sudo snap connect multimedia:tegra-camera-plug multimedia:tegra-camera-slot
+$ sudo snap connect multimedia:home
+$ sudo snap connect multimedia:var-tmp
 ```
 
 After connecting the interfaces, the nvargus-daemon contained in the snap might have to be restarted:

--- a/multimedia/snap/snapcraft.yaml
+++ b/multimedia/snap/snapcraft.yaml
@@ -35,6 +35,11 @@ plugs:
   tegra-camera-plug:
     interface: custom-device
     custom-device: tegra-camera
+  home:
+  var-tmp:
+    interface: system-files
+    write:
+      - /var/tmp
 
 slots:
   tegra-camera-slot:


### PR DESCRIPTION
## Why

The `multimedia` snap is strictly confined, and none of its apps can
write capture artifacts anywhere a user or test harness can consume
them. Observed on Ubuntu Core 22 Jetson devices (AGX Orin, Orin Nano,
IGX) while running camera validation through the snap's
`gst-launch`/`nvargus-nvraw` apps:

* AppArmor denies file creation under `/var/tmp/...` — even as root:
  `apparmor="DENIED" operation="mknod" profile="snap.multimedia.gst-launch"
  name="/var/tmp/checkbox-ng/probe-test/probe.yuv" ... fsuid=0`.
  (`/var/tmp/checkbox-ng/...` is where the Checkbox certification
  harness stores per-session artifacts.)
* Writes to `$HOME` are denied too: `nvargus_nvraw` reports
  `Error FileOperationFailed` after a successful capture (then
  segfaults in its error path); `gst-launch ... filesink` fails at
  preroll with `Permission denied`.
* The only writable host-visible location is `$SNAP_COMMON`
  (`/var/snap/multimedia/common/`), which neither interactive users
  nor test harnesses use.

The snap declares no `home` plug and no `system-files` write access —
this PR adds both, at the top level so every app inherits them:

* `home:` — interactive users can save captures into their own home
  (owner-scoped by the interface: root writing into another user's
  home stays denied, by design).
* `var-tmp` (`system-files`, write `/var/tmp`) — deliberately the
  whole of `/var/tmp` rather than a harness-specific subpath, so the
  same snap serves any tooling that stages files there.

## Validation

Validated 2026-07-18 on an Jetson AGX Orin Ubuntu Core 22 device by repacking the
installed snap with exactly these two plug entries (snap.yaml metadata
is what these snapcraft.yaml lines compile to) and connecting both
interfaces:

* `gst-launch nvarguscamerasrc` (5 × 1080p NV12 frames) →
  `/var/tmp/checkbox-ng/test/probe.yuv` = 15,552,000 bytes.
* `nvargus-nvraw` → `probe.nvraw` = 4,155,392 bytes.
* Zero write-path AppArmor denials in the validation window; the
  previously-denied `$HOME` mknod now succeeds (clean before/after).

## Notes for users

Neither interface auto-connects on Ubuntu Core — post-install setup
needs:

    sudo snap connect multimedia:home
    sudo snap connect multimedia:var-tmp

Internal tracking: OEMQA-6808 (bug), OEMQA-6807 (proposal +
validation), canonical/checkbox#2699 (the Checkbox camera jobs that
consume these paths).
